### PR TITLE
Ignore https redirection errors for ivy download

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -29,7 +29,7 @@
 
   <target name="download-ivy">
     <mkdir dir="${ivy.jar.dir}"/>
-    <get src="https://jcenter.bintray.com/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
+    <get src="https://jcenter.bintray.com/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar" dest="${ivy.jar.file}" usetimestamp="true" ignoreerrors="true"/>
   </target>
 
   <target name="init-ivy" depends="download-ivy">


### PR DESCRIPTION
Bintray can redirect https requests to their CDN using http.
Ant `get` task does not allow that, so it's better to ignore this kind of errors, as it makes our Jenkind build fail for nothing when the jar has already been downloaded before.

See https://josm.openstreetmap.de/jenkins/job/Java-EarlyAccess-JOSM-Plugins/jdk=JDK12/78/console

```
download-ivy:
      [get] Getting: https://jcenter.bintray.com/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar
      [get] To: /var/lib/jenkins/.ant/lib/ivy.jar
      [get] https://jcenter.bintray.com/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar moved to http://d29vzk4ow07wi7.cloudfront.net/5abe4c24bbe992a9ac07ca563d5bd3e8d569e9ed?response-content-disposition=attachment%3Bfilename%3D%22ivy-2.4.0.jar%22&Policy=eyJTdGF0ZW1lbnQiOiBbeyJSZXNvdXJjZSI6Imh0dHAqOi8vZDI5dnprNG93MDd3aTcuY2xvdWRmcm9udC5uZXQvNWFiZTRjMjRiYmU5OTJhOWFjMDdjYTU2M2Q1YmQzZThkNTY5ZTllZD9yZXNwb25zZS1jb250ZW50LWRpc3Bvc2l0aW9uPWF0dGFjaG1lbnQlM0JmaWxlbmFtZSUzRCUyMml2eS0yLjQuMC5qYXIlMjIiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE1Mzc0ODkzODN9LCJJcEFkZHJlc3MiOnsiQVdTOlNvdXJjZUlwIjoiMC4wLjAuMC8wIn19fV19&Signature=iSbdLWFDX5fvudWdYUCVtx~7J4jkG~hVPp3Hoax~FkWmxrlCN3Tk1dPJRZH~WoVH6K2VB3CkBhTMXKT3CfgbeHrwsGxnix~wb9VSE-CdKttZyPV-D5zHmfRl8GzDvc~gW4u3C7AuwluBwmpIPiQ8i6vgy4qFRzw-hJ5GesVA~1Ri8sSJRN9D~wt4DIOyTpjDVoW5QsOhSzk3KZj82fEVck8HLrmCBgRGa30Au-nOkSxEfFrPxyfI2CKaea~B~~wulB3i4aiQjQ1sU2mRnqiHCw7UOIRDg6OZo8laRgSnZmnLK9RjPf8QbOovxefvX6QEmU4rT7Aowfc7P8pm3XNVSQ__&Key-Pair-Id=APKAIFKFWOMXM2UMTSFA

BUILD FAILED
/var/lib/jenkins/jobs/Java-EarlyAccess-JOSM-Plugins/workspace/jdk/JDK12/build.xml:47: The following error occurred while executing this line:
/var/lib/jenkins/jobs/Java-EarlyAccess-JOSM-Plugins/workspace/jdk/JDK12/build.xml:24: The following error occurred while executing this line:
/var/lib/jenkins/jobs/Java-EarlyAccess-JOSM-Plugins/workspace/jdk/JDK12/wikipedia/build.xml:32: Redirection detected from https to http. Protocol switch unsafe, not allowed.
```