### PR TITLE
FIXUP: JCS -> JCS3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ tasks.processResources {
 archivesBaseName = "wikipedia"
 josm {
   manifest {
+    oldVersionDownloadLink 14149, "v1.1.3", new URL("https://josm.gitlab.io/plugin/wikipedia/dist/v1.1.1/wikipedia.jar")
     oldVersionDownloadLink 13927, "v1.1.0", new URL("https://josm.gitlab.io/plugin/wikipedia/dist/v1.1.0/wikipedia.jar")
     oldVersionDownloadLink 13597, "v1.0.1", new URL("https://github.com/JOSM/wikipedia/releases/download/v1.0.1/wikipedia.jar")
     oldVersionDownloadLink 12900, "34109", new URL("https://svn.openstreetmap.org/applications/editors/josm/dist/wikipedia.jar?p=34113")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # The minimum JOSM version this plugin is compatible with (can be any numeric version)
-plugin.main.version = 14149
+plugin.main.version = 16402
 # The JOSM version this plugin is currently compiled against
 # Please make sure this version is available at https://josm.openstreetmap.de/download
 # The special values "latest" and "tested" are also possible here, but not recommended.
-plugin.compile.version = 15492
+plugin.compile.version = 16402
 plugin.canloadatruntime = true
 plugin.author = floscher <incoming+josm-plugin-wikipedia-6702380-issue-@incoming.gitlab.com>, simon04
 plugin.class = org.wikipedia.WikipediaPlugin

--- a/src/main/java/org/wikipedia/Caches.java
+++ b/src/main/java/org/wikipedia/Caches.java
@@ -2,7 +2,7 @@
 package org.wikipedia;
 
 import java.io.File;
-import org.apache.commons.jcs.access.CacheAccess;
+import org.apache.commons.jcs3.access.CacheAccess;
 import org.openstreetmap.josm.data.cache.JCSCacheManager;
 import org.openstreetmap.josm.spi.preferences.Config;
 

--- a/src/main/java/org/wikipedia/api/ApiQueryClient.java
+++ b/src/main/java/org/wikipedia/api/ApiQueryClient.java
@@ -10,7 +10,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.jcs.engine.behavior.ICacheElement;
+import org.apache.commons.jcs3.engine.behavior.ICacheElement;
 import org.openstreetmap.josm.gui.bugreport.BugReportDialog;
 import org.openstreetmap.josm.tools.HttpClient;
 import org.openstreetmap.josm.tools.I18n;


### PR DESCRIPTION
See JOSM-19208. (https://josm.openstreetmap.de/ticket/19208)
The JCS package renamed itself to JCS3.

Signed-off-by: Taylor Smock <taylor.smock@kaart.com>