### PR TITLE
Blend Wikidata item name in properties table with background

### DIFF
--- a/src/main/java/org/wikipedia/data/WikidataEntry.java
+++ b/src/main/java/org/wikipedia/data/WikidataEntry.java
@@ -41,6 +41,13 @@ public class WikidataEntry extends WikipediaEntry {
         return Utils.escapeReservedCharactersHTML(bold) + " <span color='gray'>" + Utils.escapeReservedCharactersHTML(gray) + "</span>";
     }
 
+    public static String getLabelText(String bold, String colored, String color) {
+        return Utils.escapeReservedCharactersHTML(bold) +
+            " <span color='" + color + "'>" +
+            Utils.escapeReservedCharactersHTML(colored) +
+            "</span>";
+    }
+
     @Override
     public String getSearchText() {
         return Optional.ofNullable(label).orElse(article);


### PR DESCRIPTION
... instead of always using the same color

Fixes #21752.

Before: 
![image](https://user-images.githubusercontent.com/1692688/148615068-a8013038-5dcf-4b24-8a9c-2d8dcf6578fd.png)
After: 
![image](https://user-images.githubusercontent.com/1692688/148615142-0dd9ff51-5951-4408-918e-20c08ae66b36.png)

This fix doesn't change a lot of code, but due to that it may not really be optimal. Since the original code uses Swing's HTML rendering support to change the color, this fix uses the same approach to not completely change everything. Blend ratio between foreground and background is 50/50, so effectively the foreground for the item name now has 50 % opacity. One could perhaps play around a bit more with that ratio, although 75 % opacity was too close to completely opaque in my eyes, while the current result _may_ still be considered too light.