### PR TITLE
Fix JOSM #22116: Wikipedia tests are failing due to a changing Q40 wikidata item

### DIFF
--- a/test/unit/org/wikipedia/WikipediaAppTest.java
+++ b/test/unit/org/wikipedia/WikipediaAppTest.java
@@ -92,7 +92,7 @@ public class WikipediaAppTest {
         assertThat(de.get(0).label, is("Österreich"));
         assertThat(de.get(0).description, is("Staat in Mitteleuropa"));
         assertThat(en.get(0).label, is("Austria"));
-        assertThat(en.get(0).description, is("country in Europe"));
+        assertThat(en.get(0).description, is("country in Central Europe"));
     }
 
     @Test


### PR DESCRIPTION
https://josm.openstreetmap.de/ticket/22116